### PR TITLE
Allow specification of file path for NTP peerstats/loopstats files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ksh scripts using gawk, gnuplot and gnuplot-x11
 * ntptconv
 * ntp_shavail
 
+Ubuntu prerequisites:  apt-get install ksh gawk gnuplot gnuplot-x11
 
 ## ntp_shps 
 
@@ -22,7 +23,8 @@ ksh scripts using gawk, gnuplot and gnuplot-x11
       author: ntpgraph@ma.yer.at
 
     usage: ntp_shps [ -L ] -s|-i|-o|-d|-r|-j | -O|-D|-E|-S|-P [ -p value ] [ -t value ] [ -m min max ] [ -c value ] [ -l ] [ -w value ] [ -x range ][ -y range ] [ -F n ] [ -L ] [ -f IMG ] [ -Y string ] [ IP ] DATE
-       date is MMDD in year 2016 or YYYYMMDD or . or - ( . is today, - is yesterday  )
+       DATESPEC is MMDD in year 2017 or YYYYMMDD or . (today) or - (yesterday) 
+       DATESPEC may also be path to peerstats/loopstats file
        IP address  - only for peerstats graph, not for loopstats
        -s          - success rate
        -p value    - poll interval used for calculation of success rate, default 64
@@ -123,7 +125,8 @@ With debug option -D the fit log file "/tmp/fit.log.$$" will not be deleted.
       author: ntpgraph@ma.yer.at
     
     usage: /opt/iiasa/bin/ntp_shdiff [ -a ] [ -f ] [ -l ] [ -m value ] [ -c low high ] [ -t value ] [ -w value ] [ -y range ] [ -F n ] [ -L ] IP1 IP2 date
-       date is MMDD in year 2016 or YYYYMMDD or . or - ( . is today, - is yesterday  )
+       DATESPEC is MMDD in year 2017 or YYYYMMDD or . (today) or - (yesterday) 
+       DATESPEC may also be path to peerstats/loopstats file
        -x range      - low:high, example 1:10 , default autorange -0.5:24.8 , time in hours
        -y range      - low:high, example -0.1:0.1 , default autorange
        -a            - print average line

--- a/ntp_shavail
+++ b/ntp_shavail
@@ -40,7 +40,7 @@ while test $# -gt $MINARGS -o do_once -eq 1
   do
     do_once=0
     case $1 in
-      -D ) DEBUG=y ; shift ;;
+      -D ) DEBUG=y ; set -x ; shift ;;
       -f ) FILE="set output \"plot_$$.$2\" "
            STERM="set terminal $2 size 900,500"
            LINEWIDTH=1
@@ -125,6 +125,8 @@ fi
 # awk is needed for solaris to strip off the leading blanks
 STATSDIR=`grep statsdir $CONF | grep -v '^#' | tr '""' '  ' | head -1 | $AWK '{ print ( $2 ) }'`
 PEERSTATS=`grep filegen $CONF | grep peerstats | grep -v '^#' | head -1 | $AWK '{ print ( $4 ) }'`
+PEERSTATS=${PEERSTATS:-peerstats} # in case filegen keyword not found
+
 if test "$DEBUG" == y
   then
     echo CONF $CONF

--- a/ntp_shdiff
+++ b/ntp_shdiff
@@ -49,12 +49,14 @@ LBLPOS=0.95
 
 
 thisusage(){
+    set +x
     echo 
     echo "show time difference for 2 NTP server - v 2016 05 09 "
     echo "  author: ntpgraph@ma.yer.at "
     echo
-    echo "usage: $0 [ -a ] [ -f ] [ -l ] [ -m value ] [ -c low high ] [ -t value ] [ -w value ] [ -y range ] [ -F n ] [ -L ] IP1 IP2 date "
-    echo "       date is MMDD in year $YEAR or YYYYMMDD or . or - ( . is today, - is yesterday  ) "
+    echo "usage: $0 [ -a ] [ -f ] [ -l ] [ -m value ] [ -c low high ] [ -t value ] [ -w value ] [ -y range ] [ -F n ] [ -L ] IP1 IP2 DATESPEC "
+    echo "       DATESPEC is MMDD in year $YEAR or YYYYMMDD or . (today) or - (yesterday) "
+    echo "       DATESPEC can also be path to peerstats file"
     echo "       -x range      - low:high, example 1:10 , default autorange -0.5:24.8 , time in hours "
     echo "       -y range      - low:high, example -0.1:0.1 , default autorange " 
     echo "       -a            - print average line " 
@@ -100,7 +102,7 @@ while test $# -gt 3 -o do_once -eq 1
            XTICS=2
            echo $FILE ; shift ; shift ;; 
       -l ) LINES="with lines" ; shift ;;
-      -D ) DEBUG=y ; set -x ; shift ;;
+      -D ) DEBUG=y ; set -x; shift ;;
       -m ) TIMEDIFFLOW=-$2 ; TIMEDIFFHIGH=$2 ; shift ; shift ; SHOWOPT="$SHOWOPT -m $TIMEDIFFHIGH" ;; 
       -c ) TIMEDIFFLOW=$2 ; TIMEDIFFHIGH=$3 ; shift ; shift ; shift ; SHOWOPT="$SHOWOPT -c $TIMEDIFFLOW $TIMEDIFFHIGH" ;; 
       -F ) POLYN=$2 ; shift ; shift ; FFIT=', line(x) ' ; SHOWOPT="$SHOWOPT -F $POLYN" ;; 
@@ -151,7 +153,9 @@ if test -z "$FILE"
 fi
 
 
-# very rudimentary check of date
+# if date field is a valid filename, use it as datasource
+# otherwise perform rudimentary date check
+TITLEHOST=$(uname -n)
 case "$MDATE" in
   [0-9\?][0-9\?][0-9\?][0-9\?] ) 
 	SELDATE=$YEAR$MDATE ;;
@@ -159,9 +163,15 @@ case "$MDATE" in
 	SELDATE=$MDATE ;;
   \. ) 	SELDATE=`TZ=GMT date +%Y%m%d` ;;
   - )   SELDATE=`TZ=GMT+24 date +%Y%m%d` ;;
-  * )   echo $0: wrong date format - must be MMDD or YYYYMMDD or . 1>&2
-        thisusage
-        exit 1
+  * )   if [ -f "$MDATE" ]
+        then
+		STATSFILEPATH=$MDATE
+		TITLEHOST=$(basename $STATSFILEPATH)
+        else
+	    echo "$0: wrong date format - must be one of {MMDD | YYYYMMDD | . | - } or a filename" 1>&2
+		thisusage
+		exit 1
+        fi
         ;;
 esac
 
@@ -201,24 +211,24 @@ fi
 # awk is needed for solaris to strip off the leading blanks 
 STATSDIR=`grep statsdir $CONF | grep -v '^#' | tr '""' '  ' | head -1 | $AWK '{ print ( $2 ) }'`
 PEERSTATS=`grep filegen $CONF | grep peerstats | grep -v '^#' | head -1 | $AWK '{ print ( $4 ) }'`
-PEERSTATS=${PEERSTATS:-peerstats} # in case filegen keyword not found
-
+PEERSTATS=${PEERSTATS:-peerstats} # in case no filegen keyword in ntp.conf
 : echo STATSDIR $STATSDIR PEERSTATS $PEERSTATS
+STATSFILEPATH=${STATSFILEPATH:-$STATSDIR/$PEERSTATS.$SELDATE}
 
 # does at least one file exist ? 
-ls $STATSDIR/${PEERSTATS}.$SELDATE > /dev/null 2>&1 
+ls $STATSFILEPATH > /dev/null 2>&1 
 if test $? -ne 0 
   then
-    echo $0: $STATSDIR/${PEERSTATS}.$SELDATE not found 
+    echo $0: $STATSFILEPATH not found 
     exit 1
 fi
-DAYS=`ls  $STATSDIR/${PEERSTATS}.$SELDATE | wc -l | $AWK '{ print $1 }'`
+DAYS=`ls  $STATSFILEPATH | wc -l | $AWK '{ print $1 }'`
 : echo 
 
 # peerstats column 2 are seconds after midnight 
 # myarray enhaelt anzahl gefundenet zeilen pro stunde 
 : echo $AWK -v DAYS=$DAYS -v TIMESPERH=$TIMESPERH -v IP1=$IP1 -v IP2=$IP2 
-cat $STATSDIR/$PEERSTATS.$SELDATE | \
+cat $STATSFILEPATH | \
 $AWK -v DAYS=$DAYS -v TIMESPERH=$TIMESPERH -v IP1=$IP1 -v IP2=$IP2 -v TIMEDIFFLOW=$TIMEDIFFLOW -v TIMEDIFFHIGH=$TIMEDIFFHIGH '
   BEGIN {
     # print ( "awk begin " ) ; 
@@ -345,7 +355,7 @@ FIT_LOG=/tmp/fit.log.$$
 gnuplot << EOF
   $TERM
   $FILE 
-  set title "`uname -n`: $IP1 - $IP2 - $SELDATE \n $HOST1 - $HOST2 $AVG\n$SHOWOPT"
+  set title "$TITLEHOST: $IP1 - $IP2 - $SELDATE \n $HOST1 - $HOST2 $AVG\n$SHOWOPT"
   set xlabel "hour"
   set ylabel "offset (sec)"
   set xtics $XTICS
@@ -373,7 +383,7 @@ if test "$DEBUG" == y
       then
         ls -l $FIT_LOG
     fi
-    echo STATSDIR $STATSDIR PEERSTATS ${PEERSTATS}.$SELDATE
+    echo STATSDIR $STATSDIR PEERSTATS $STATSFILEPATH
     echo plotfile: $LIST
     echo "$AVG "
   else

--- a/ntp_shdiff
+++ b/ntp_shdiff
@@ -100,7 +100,7 @@ while test $# -gt 3 -o do_once -eq 1
            XTICS=2
            echo $FILE ; shift ; shift ;; 
       -l ) LINES="with lines" ; shift ;;
-      -D ) DEBUG=y ; shift ;;
+      -D ) DEBUG=y ; set -x ; shift ;;
       -m ) TIMEDIFFLOW=-$2 ; TIMEDIFFHIGH=$2 ; shift ; shift ; SHOWOPT="$SHOWOPT -m $TIMEDIFFHIGH" ;; 
       -c ) TIMEDIFFLOW=$2 ; TIMEDIFFHIGH=$3 ; shift ; shift ; shift ; SHOWOPT="$SHOWOPT -c $TIMEDIFFLOW $TIMEDIFFHIGH" ;; 
       -F ) POLYN=$2 ; shift ; shift ; FFIT=', line(x) ' ; SHOWOPT="$SHOWOPT -F $POLYN" ;; 
@@ -201,6 +201,8 @@ fi
 # awk is needed for solaris to strip off the leading blanks 
 STATSDIR=`grep statsdir $CONF | grep -v '^#' | tr '""' '  ' | head -1 | $AWK '{ print ( $2 ) }'`
 PEERSTATS=`grep filegen $CONF | grep peerstats | grep -v '^#' | head -1 | $AWK '{ print ( $4 ) }'`
+PEERSTATS=${PEERSTATS:-peerstats} # in case filegen keyword not found
+
 : echo STATSDIR $STATSDIR PEERSTATS $PEERSTATS
 
 # does at least one file exist ? 

--- a/ntp_shps
+++ b/ntp_shps
@@ -57,12 +57,14 @@ AVGFILE=/tmp/ntp_shps_average
 
 
 thisusage(){
+    set +x
     echo 
     echo "show NTP peerstats or loopstats values as graph  - v 2016 12 18 "
     echo "  author: ntpgraph@ma.yer.at "
     echo 
-    echo "usage: $0 [ -L ] -s|-i|-o|-d|-r|-j | -O|-D|-E|-S|-P [ -p value ] [ -a ] [ -A ] [ -t value ] [ -m min max ] [ -c value ] [ -l ] [ -w value ] [ -x range ][ -y range ] [ -F n ] [ -L ] [ -f IMG ] [ -Y string ] [ IP ] DATE "
-    echo "       date is MMDD in year $YEAR or YYYYMMDD or . or - ( . is today, - is yesterday  ) "
+    echo "usage: $0 [ -L ] -s|-i|-o|-d|-r|-j | -O|-D|-E|-S|-P [ -p value ] [ -a ] [ -A ] [ -t value ] [ -m min max ] [ -c value ] [ -l ] [ -w value ] [ -x range ][ -y range ] [ -F n ] [ -L ] [ -f IMG ] [ -Y string ] [ IP ] DATESPEC "
+    echo "       DATESPEC is MMDD in year $YEAR or YYYYMMDD or . (today) or - (yesterday) "
+    echo "       DATESPEC may also be path to peerstats/loopstats file"
     echo "       IP address  - only for peerstats graph, not for loopstats "
     echo "       -s          - success rate "
     echo "       -p value    - poll interval used for calculation of success rate, default 64 "
@@ -123,7 +125,7 @@ while test $# -gt $ARGC -o do_once -eq 1
       -r ) DTYPE=r ; LINES="" ; YLBL='roundtrip delay' ; shift ; UNIQARGCNT=$((UNIQARGCNT+1)) ;;
       -d ) DTYPE=d ; LINES="" ; YLBL=dispersion ; shift ; UNIQARGCNT=$((UNIQARGCNT+1)) ;;
       -j ) DTYPE=j ; LINES="" ; YLBL=jitter ; shift ; UNIQARGCNT=$((UNIQARGCNT+1)) ;;
-      -Z ) DEBUG=y ; set -x ; shift ;; 
+      -Z ) DEBUG=y ; set -x; shift ;; 
       -f ) FILE="set output \"plot_$$.$2\" "
            STERM="set terminal $2"
            LINEWIDTH=1
@@ -199,7 +201,9 @@ if test $# -eq 2
     MDATE=$1
 fi
 
-# very rudimentary check of date 
+# if date field is a valid filename, use it as datasource
+# otherwise perform rudimentary date check
+TITLEHOST=$(uname -n)
 case "$MDATE" in 
   [0-9\?][0-9\?][0-9\?][0-9\?] ) 
         SELDATE=$YEAR$MDATE ;;
@@ -207,9 +211,15 @@ case "$MDATE" in
         SELDATE=$MDATE ;;
   \. )  SELDATE=`TZ=GMT date +%Y%m%d` ;;
   - )   SELDATE=`TZ=GMT+24 date +%Y%m%d` ;;
-  * )   echo $0: wrong date format - must be MMDD or . 1>&2 
-	thisusage
-    	exit 1
+  * )   if [ -f "$MDATE" ]
+        then
+		STATSFILEPATH=$MDATE
+		TITLEHOST=$(basename $STATSFILEPATH)
+        else
+	    echo "$0: wrong date format - must be one of {MMDD | YYYYMMDD | . | - } or a filename" 1>&2
+		thisusage
+		exit 1
+        fi
     	;;
 esac
 
@@ -268,21 +278,21 @@ fi
 STATSDIR=`grep statsdir $CONF | grep -v '^#' | tr '""' '  ' | head -1 | $AWK '{ print ( $2 ) }'`
 STATSFILE=`grep filegen $CONF | grep $STATSTYPE | grep -v '^#' | head -1 | $AWK '{ print ( $4 ) }'`
 STATSFILE=${STATSFILE:-$STATSTYPE} # default in case no "filegen" in ntp.conf
-
+STATSFILEPATH=${STATSFILEPATH:-$STATSDIR/$STATSFILE.$SELDATE}
 if test "$DEBUG" == y
   then
     echo CONF $CONF
-    echo STATSDIR $STATSDIR STATSFILE $STATSFILE.$SELDATE
+    echo STATSDIR $STATSDIR STATSFILE $STATSFILEPATH
     echo DAYS=$DAYS TIMESPERH=$TIMESPERH CNTONLY=$CNTONLY POLL=$POLL 
 fi
 
-if test ! -f $STATSDIR/${STATSFILE}.$SELDATE 
+if test ! -f $STATSFILEPATH 
   then 
-    echo $0: file $STATSDIR/${STATSFILE}.$SELDATE not found 
+    echo $0: file $STATSFILEPATH not found 
     exit 1 
 fi 
 
-DAYS=`ls  $STATSDIR/${STATSFILE}.$SELDATE | wc -l | $AWK '{ print $1 }'` 
+DAYS=`ls  $STATSFILEPATH | wc -l | $AWK '{ print $1 }'` 
 : echo 
 
 # peerstats column 2 are seconds after midnight 
@@ -291,7 +301,7 @@ DAYS=`ls  $STATSDIR/${STATSFILE}.$SELDATE | wc -l | $AWK '{ print $1 }'`
 if test $DTYPE == s 
   then 
     # show success graph 
-    cat $STATSDIR/$STATSFILE.$SELDATE | \
+    cat $STATSFILEPATH | \
     grep $IP1 | \
     $AWK -v DAYS=$DAYS -v TIMESPERH=$TIMESPERH -v CNTONLY=$CNTONLY -v POLL=$POLL '
       BEGIN {
@@ -314,7 +324,7 @@ fi
 if test $DTYPE == i 
   then 
     # show graph with intervals 
-    cat $STATSDIR/$STATSFILE.$SELDATE | \
+    cat $STATSFILEPATH | \
     grep $IP1 | \
     $AWK -v DAYS=$DAYS -v TIMESPERH=$TIMESPERH -v CNTONLY=$CNTONLY -v POLL=$POLL '
       BEGIN {
@@ -353,7 +363,7 @@ if test $DTYPE == o -o $DTYPE == d -o $DTYPE == j -o $DTYPE == r -o $DTYPE == O 
       * ) echo "$0: fatal program error " 1>&2 
 	  exit 1 ;; 
     esac 
-    cat $STATSDIR/$STATSFILE.$SELDATE | \
+    cat $STATSFILEPATH | \
     grep $IP1 | \
     $AWK -v DAYS=$DAYS -v TIMESPERH=$TIMESPERH -v CNTONLY=$CNTONLY -v POLL=$POLL -v COLUMN=$COLUMN -v MIN=$MIN -v MAX=$MAX '
       BEGIN {
@@ -402,24 +412,24 @@ fi
 type ip > /dev/null 2>&1 
 if test $? -eq 0 
   then 
-    MYIPIS="`uname -n`/`ip route get 244.0.0.0 | head -1 | $AWK '{ print $7 }'`"
+    MYIPIS="$TITLEHOST/`ip route get 244.0.0.0 | head -1 | $AWK '{ print $7 }'`"
   else 
-    MYIPIS="`uname -n`"
+    MYIPIS="$TITLEHOST"
 fi
 
 # IP1 ist . fuer loopstats file 
 if test "$IP1" == '.' 
   then 
-    TITLE="$MYIPIS $STATSTYPE - $SELDATE "
+    TITLE="$MYIPIS $STATSTYPE - ${SELDATE:-} "
   else 
     # if getent does not exist $HOST1 is empty 
     HOST1=`getent hosts $IP1 2> /dev/null | $AWK '{ print $2 }'`
     # if reverse lookup does not work take the IP
     if test -z "$HOST1"
       then
-        TITLE="$MYIPIS $STATSTYPE - $IP1 - $SELDATE "
+        TITLE="$MYIPIS $STATSTYPE - $IP1 - ${SELDATE:-} "
       else 
-        TITLE="$MYIPIS $STATSTYPE - $IP1 - $HOST1 - $SELDATE "
+        TITLE="$MYIPIS $STATSTYPE - $IP1 - $HOST1 - ${SELDATE:-} "
     fi
 fi
 

--- a/ntp_shps
+++ b/ntp_shps
@@ -123,7 +123,7 @@ while test $# -gt $ARGC -o do_once -eq 1
       -r ) DTYPE=r ; LINES="" ; YLBL='roundtrip delay' ; shift ; UNIQARGCNT=$((UNIQARGCNT+1)) ;;
       -d ) DTYPE=d ; LINES="" ; YLBL=dispersion ; shift ; UNIQARGCNT=$((UNIQARGCNT+1)) ;;
       -j ) DTYPE=j ; LINES="" ; YLBL=jitter ; shift ; UNIQARGCNT=$((UNIQARGCNT+1)) ;;
-      -Z ) DEBUG=y ; shift ;; 
+      -Z ) DEBUG=y ; set -x ; shift ;; 
       -f ) FILE="set output \"plot_$$.$2\" "
            STERM="set terminal $2"
            LINEWIDTH=1
@@ -267,6 +267,8 @@ fi
 # awk is needed for solaris to strip off the leading blanks
 STATSDIR=`grep statsdir $CONF | grep -v '^#' | tr '""' '  ' | head -1 | $AWK '{ print ( $2 ) }'`
 STATSFILE=`grep filegen $CONF | grep $STATSTYPE | grep -v '^#' | head -1 | $AWK '{ print ( $4 ) }'`
+STATSFILE=${STATSFILE:-$STATSTYPE} # default in case no "filegen" in ntp.conf
+
 if test "$DEBUG" == y
   then
     echo CONF $CONF


### PR DESCRIPTION
In my work environment, we copy NTP peerstats files from multiple production hosts onto a central host and look at them there.  These patches let us generate the graphs on the central host by expanding the <DATE> specification to include a file path.

Other fixes:
* add "-x" option to show script flow when debug mode is on
* "filegen" keyword is optional in ntp.conf so provide reasonable default if it is not found